### PR TITLE
Add stable debugNames to AuthComponent2 for test addressability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Unreleased
+
+### AuthComponent2
+
+- **Added stable `debugName` values to key interactive elements** in `AuthComponent2`, making it possible for AI driver tests and automated test suites to reliably target them without fragile index-based paths:
+  - `"primaryInput"` — the email/phone/username text input
+  - `"cancelButton"` — the back/cancel button shown while proofs are in progress
+  - `"loginButton"` — the final login button in the finalization screen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,41 @@
 
 ## Unreleased
 
-### AuthComponent2
+### Auth Components
 
-- **Added stable `debugName` values to key interactive elements** in `AuthComponent2`, making it possible for AI driver tests and automated test suites to reliably target them without fragile index-based paths:
-  - `"primaryInput"` — the email/phone/username text input
-  - `"cancelButton"` — the back/cancel button shown while proofs are in progress
-  - `"loginButton"` — the final login button in the finalization screen
+- **Added stable `debugName` values to all interactive auth elements**, making it possible for AI driver tests and automated test suites to reliably target every interactive element without fragile index-based paths.
+
+  **`AuthComponent` / `authComponent()`**
+  - `"primaryInput"` — email/phone/username text input
+  - `"cancelButton"` — back/cancel button shown while proofs are in progress
+  - `"usePasskeyButton"` — passkey/WebAuthN trigger button
+  - `"rememberDeviceCheckbox"` — "This is my device" checkbox
+  - `"keepLoggedInCheckbox"` — extended session duration checkbox
+  - `"loginButton"` — final login button in the finalization screen
+  - Proof picker buttons use the proof method name as `debugName` (e.g., `"Email Code"`, `"Text Code"`, `"Enter Password"`, `"Use Authenticator App"`, `"Enter Backup Code"`)
+
+  **`ReAuthComponent` / `reAuthComponent()`**
+  - `"loginButton"` — final login button
+  - Proof picker buttons use the proof method name as `debugName` (same as above)
+
+  **`EmailProofComponent`**
+  - `"codeInput"` — email verification code text input
+  - `"submitButton"` — submit code button
+  - `"resendButton"` — resend code button
+
+  **`SmsProofComponent`**
+  - `"codeInput"` — SMS verification code text input
+  - `"submitButton"` — submit code button
+  - `"resendButton"` — resend code button
+
+  **`PasswordProofComponent`**
+  - `"passwordInput"` — password text input
+  - `"submitButton"` — submit button
+
+  **`TotpProofComponent`**
+  - `"codeInput"` — TOTP code text input
+  - `"submitButton"` — submit button
+
+  **`BackupCodeProofComponent`**
+  - `"codeInput"` — backup code text input
+  - `"submitButton"` — submit button

--- a/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/BackupCodeProofComponent.kt
+++ b/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/BackupCodeProofComponent.kt
@@ -89,6 +89,7 @@ data class BackupCodeProofComponent(val p: ProofClientEndpoints.BackupCode, val 
 
             fieldNoErrorText("Backup Code") {
                 textInput {
+                    debugName = "codeInput"
                     // Hint shows typical backup code format with hyphens
                     ::hint { "xxxxx-xxxxx-xxxxx-xxxxx" }
                     // Auto-focus for immediate code entry
@@ -103,6 +104,7 @@ data class BackupCodeProofComponent(val p: ProofClientEndpoints.BackupCode, val 
             SubtextSemantic.onNext.errorText()
 
             important.button {
+                debugName = "submitButton"
                 centered.text("Submit")
                 action = proveBackupCode
             }

--- a/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/EmailProofComponent.kt
+++ b/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/EmailProofComponent.kt
@@ -96,6 +96,7 @@ data class EmailProofComponent(val p: ProofClientEndpoints.Email) : ProofCompone
 
                 fieldNoErrorText("Login code emailed to ${option.value ?: ""}") {
                     textInput {
+                        debugName = "codeInput"
                         ::hint { "ABCDEF" }
                         // Auto-focus once email is sent for better UX
                         reactive { if (challenge.state().ready) requestFocus() }
@@ -108,6 +109,7 @@ data class EmailProofComponent(val p: ProofClientEndpoints.Email) : ProofCompone
                 SubtextSemantic.onNext.errorText()
 
                 important.buttonTheme.button {
+                    debugName = "submitButton"
                     centered.text("Submit")
                     action = proveEmailOwnership
                 }
@@ -117,6 +119,7 @@ data class EmailProofComponent(val p: ProofClientEndpoints.Email) : ProofCompone
                 // 2. Countdown timer for remaining cooldown period
                 // 3. "Send new code" when cooldown expires
                 button {
+                    debugName = "resendButton"
                     // Button is disabled during cooldown (except first 3 seconds when showing "Sent!")
                     ::enabled { nowBySecond() !in challenge().timestamp + 3.seconds..challenge().timestamp + resendTime }
 

--- a/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/PasswordProofComponent.kt
+++ b/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/PasswordProofComponent.kt
@@ -87,6 +87,7 @@ data class PasswordProofComponent(val p: ProofClientEndpoints.Password, val type
 
             fieldNoErrorText("Password") {
                 textInput {
+                    debugName = "passwordInput"
                     ::hint { "" }
                     // Auto-focus for immediate password entry
                     requestFocus()
@@ -99,6 +100,7 @@ data class PasswordProofComponent(val p: ProofClientEndpoints.Password, val type
             SubtextSemantic.onNext.errorText()
 
             important.button {
+                debugName = "submitButton"
                 centered.text("Submit")
                 action = provePasswordOwnership
             }

--- a/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/SmsProofComponent.kt
+++ b/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/SmsProofComponent.kt
@@ -96,6 +96,7 @@ data class SmsProofComponent(val p: ProofClientEndpoints.Sms) : ProofComponent {
             shownWhen { challenge.state().ready }.col {
                 fieldNoErrorText("Login code texted to ${option.value ?: ""}") {
                     textInput {
+                        debugName = "codeInput"
                         ::hint { "ABCDEF" }
                         // Auto-focus once SMS is sent for better UX
                         reactive { if (challenge.state().ready) requestFocus() }
@@ -108,6 +109,7 @@ data class SmsProofComponent(val p: ProofClientEndpoints.Sms) : ProofComponent {
                 SubtextSemantic.onNext.errorText()
 
                 important.buttonTheme.button {
+                    debugName = "submitButton"
                     centered.text("Submit")
                     action = proveSmsOwnership
                 }
@@ -117,6 +119,7 @@ data class SmsProofComponent(val p: ProofClientEndpoints.Sms) : ProofComponent {
                 // 2. Countdown timer for remaining cooldown period
                 // 3. "Send new code" when cooldown expires
                 button {
+                    debugName = "resendButton"
                     // Button is disabled during cooldown (except first 3 seconds when showing "Sent!")
                     ::enabled { nowBySecond() !in challenge().timestamp + 3.seconds..challenge().timestamp + resendTime }
 

--- a/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/TotpProofComponent.kt
+++ b/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/TotpProofComponent.kt
@@ -88,6 +88,7 @@ data class TotpProofComponent(val p: ProofClientEndpoints.TimeBasedOTP, val type
 
             fieldNoErrorText("One-time Password from App") {
                 textInput {
+                    debugName = "codeInput"
                     ::hint { "000000" }
                     // Auto-focus for immediate code entry
                     requestFocus()
@@ -101,6 +102,7 @@ data class TotpProofComponent(val p: ProofClientEndpoints.TimeBasedOTP, val type
             SubtextSemantic.onNext.errorText()
 
             important.button {
+                debugName = "submitButton"
                 centered.text("Submit")
                 action = proveTotpOwnership
             }

--- a/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/authComponent.kt
+++ b/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/authComponent.kt
@@ -262,6 +262,7 @@ open class AuthComponent(
             val autoFillAvailable =
                 rememberSuspending { ClientAuthenticator.getClientAuthenticator().autofillAvailable() }
             textInput {
+                debugName = "primaryInput"
                 hint = when {
                     endpoints.emailProof != null && endpoints.smsProof != null -> "me@email.com OR 800-123-4567"
                     endpoints.emailProof != null -> "me@email.com"
@@ -331,6 +332,7 @@ open class AuthComponent(
 
         shownWhen { proofs().isNotEmpty() || currentProof() != null }.row {
             centered.button {
+                debugName = "cancelButton"
                 padding = 0.2.rem
                 icon(Icon.arrowBack, "Cancel")
                 onClick {
@@ -413,6 +415,7 @@ open class AuthComponent(
 
 
             important.buttonTheme.button {
+                debugName = "loginButton"
                 centered.text("Login")
                 onClick {
                     val result = subject.logInV2(

--- a/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/authComponent.kt
+++ b/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/authComponent.kt
@@ -357,6 +357,7 @@ open class AuthComponent(
                     centered.text("Or")
 
                     card.buttonTheme.button {
+                        debugName = "usePasskeyButton"
                         centered.row {
                             icon(Icon.Companion.passkey, "")
                             text("Use Passkey")
@@ -392,13 +393,14 @@ open class AuthComponent(
             }
             centered.h5("Ready to login")
             shownWhen { knownDeviceOptions() != null }.row {
-                centered.checkbox { checked bind rememberDevice }
+                centered.checkbox { debugName = "rememberDeviceCheckbox"; checked bind rememberDevice }
                 centered.text {
                     content = "This is my device"
                 }
             }
             shownWhen { rememberDevice() || knownDeviceOptions() == null }.row {
                 centered.checkbox {
+                    debugName = "keepLoggedInCheckbox"
                     checked bind desiredSessionLength.lens(
                         get = { it != 1.days },
                         set = { if (it) null else 1.days }
@@ -475,6 +477,7 @@ open class AuthComponent(
             // Render button for each available proof method
             forEachAnimated(proofOptions) {
                 card.buttonTheme.button {
+                    debugName = it.name
                     centered.sizeConstraints(width = 16.rem).row {
                         icon(it.icon, "")
                         text(it.name)

--- a/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/reAuthComponent.kt
+++ b/client/src/commonMain/kotlin/com/lightningkite/kiteui/auth/reAuthComponent.kt
@@ -194,6 +194,7 @@ open class ReAuthComponent(
             centered.h5("Ready to login")
 
             important.buttonTheme.button {
+                debugName = "loginButton"
                 centered.text("Login")
                 onClick {
                     val result = subject.logInV2(
@@ -235,6 +236,7 @@ open class ReAuthComponent(
             // Render button for each available proof method
             forEachAnimated(proofOptions) { it ->
                 card.buttonTheme.button {
+                    debugName = it.first.name
                     centered.sizeConstraints(width = 16.rem).row {
                         icon(it.first.icon, "")
                         text(it.first.name)


### PR DESCRIPTION
## Summary

- Adds `debugName = "primaryInput"` to the email/phone/username text input in `renderPrimaryIdentifier`
- Adds `debugName = "cancelButton"` to the back/cancel button
- Adds `debugName = "loginButton"` to the final login button in `renderFinalize`

Previously, AI driver tests and automated test suites had to target these elements using fragile index-based paths like `"0/7/0/3"`, which broke whenever the auth UI changed layout. These stable names make tests resilient to structural changes.

## Test plan

- [ ] Verify `AuthComponent2` renders correctly on all platforms (no visual change expected)
- [ ] Confirm AI driver tests can address `"primaryInput"`, `"cancelButton"`, `"loginButton"` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)